### PR TITLE
fixed laminas-log to 2.15.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "laminas/laminas-servicemanager": "^3.10",
         "laminas/laminas-form": "^3.1.1",
         "laminas/laminas-dependency-plugin": "^2.2",
-        "laminas/laminas-log": "^2.15"
+        "laminas/laminas-log": "2.15.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.1",


### PR DESCRIPTION
#9 
fixed version to 2.15.2 to allow normal usage for the time